### PR TITLE
Update index page link

### DIFF
--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -40,7 +40,7 @@
 
             <li class="govuk-task-list__item govuk-task-list__item--with-link">
               <div class="govuk-task-list__name-and-hint">
-                <a class="govuk-link govuk-task-list__link" href="features/application-stages/0-preapplication.html">Application stages</a>
+                <a class="govuk-link govuk-task-list__link" href="features/application-stages/1-accepted.html">Application stages</a>
                 <div class="govuk-task-list__hint">Application stages accordion designs</div>
               </div>
               <div class="govuk-task-list__status">


### PR DESCRIPTION
As pre-application stage will always be completed, added initial link to the 'accepted' page to show the initial stage accurately.