### PR TITLE
Remove teal masthead banner from words we use page

### DIFF
--- a/app/views/features/words-we-use/2-words-we-use.html
+++ b/app/views/features/words-we-use/2-words-we-use.html
@@ -3,22 +3,18 @@
 Crown Developments prototype
 {% endset%}
 
-{% block beforeContent %}
-    <div class="full-bleed cd-banner">
-        <div class="govuk-width-container">
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Words we use</h1>
-            <p class="govuk-body">
-                Definitions of the words we use to talk about Crown developments.
-            </p>
-        </div>
-    </div>
-{% endblock %}
-
 {% block content %}
 
+    <h1 class="govuk-heading-xl">Words we use</h1>
+    <p class="govuk-body">
+        Definitions of the words we use to talk about Crown developments.
+    </p>
+
     <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-<nav aria-label="Glossary letters"> <h2 class="govuk-heading-m">Jump to letter</h2>
+        <div class="govuk-grid-column-two-thirds">
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+            <nav aria-label="Glossary letters">
+                <h2 class="govuk-heading-m">Jump to a letter</h2>
                 <ul class="govuk-list" style="display:flex; flex-wrap:wrap; gap:10px; list-style:none; ">
                     <li>
                         <a href="#A" class="govuk-link govuk-!-font-weight-bold">A</a>
@@ -74,7 +70,7 @@ Crown Developments prototype
                     <li>Z</li>
                 </ul>
             </nav>
-
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
             <section id="A" class="letter-section">
                 <h2 class="govuk-heading-l">A</h2>
@@ -171,7 +167,7 @@ Crown Developments prototype
                     <p class="govuk-body">In the context of a Crown Development application, this refers to proposed developments that have significant implications for the nation, impacting areas beyond local interests. A development is considered of national importance if it: involves national security or foreign governments, contributes to national public services or infrastructure, supports responses to emergencies, has significant economic, social, or environmental effects at a regional or national level.</p>
                 </div>
             </section>
-                        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
             <section id="P" class="letter-section">
                 <h2 class="govuk-heading-l">P</h2>
@@ -188,7 +184,7 @@ Crown Developments prototype
                     <p class="govuk-body">A written document containing the evidence that a specific witness will give at an inquiry.</p>
                 </div>
             </section>
-                        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
             <section id="R" class="letter-section">
                 <h2 class="govuk-heading-l">R</h2>
@@ -205,13 +201,14 @@ Crown Developments prototype
                     <p class="govuk-body">Refers to Rule 13(4) of the Inquiries Rules which allows interested parties to request a more active role in the process. This is granted at the Planning Inspector’s discretion. Rule 13 parties must submit a statement of case and proof(s) of evidence, and will be entitled to appear at the inquiry.</p>
                 </div>
             </section>
-                        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
             <section id="S" class="letter-section">
                 <h2 class="govuk-heading-l">S</h2>
                 <div class="term" id="statutory-party">
                     <h3 class="govuk-heading-m">Statutory party</h3>
-                    <p class="govuk-body">Any person who has an interest in the land that the applicant is looking to build on. For example, owners/co-owners/occupiers/tenants who are affected by the application. When an applicant submits an application, they are responsible for notifying statutory parties. </p>
+                    <p class="govuk-body">Any person who has an interest in the land that the applicant is looking to build on. For example, owners/co-owners/occupiers/tenants who are affected by the application. When an applicant submits an application, they are responsible for notifying statutory parties.
+                    </p>
                 </div>
                 <div class="term" id="statement-of-case">
                     <h3 class="govuk-heading-m">Statement of case</h3>
@@ -232,7 +229,8 @@ Crown Developments prototype
                 </div>
                 <div class="term" id="the-written-representations-procedure">
                     <h3 class="govuk-heading-m">Written representations procedure</h3>
-                    <p class="govuk-body">Refers to the comment and any supporting documents submitted by an interested party on a planning application. Written representations are used to express views on the proposed development and are considered by Planning Inspectors before they make a decision on an application. </p>
+                    <p class="govuk-body">Refers to the comment and any supporting documents submitted by an interested party on a planning application. Written representations are used to express views on the proposed development and are considered by Planning Inspectors before they make a decision on an application.
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Updating 'Words we use' page design - teal masthead component should only be shown on top level landing pages for consistency with other PINS services.